### PR TITLE
Fix duplicate nav headers

### DIFF
--- a/_includes/body/nav.html
+++ b/_includes/body/nav.html
@@ -4,21 +4,24 @@
   {% assign documents = site.documents | where: "menu", true %}
   {% assign nodes = pages | concat: documents | sort: "order" %}
   {% for node in nodes %}
-    {% unless node.redirect_to %}
-      <li>
-        <a
-          {% if forloop.first %}id="_navigation"{% endif %}
-          href="{{ node.url | relative_url }}"
-          class="sidebar-nav-item{% if page.url contains node.url %} active{% endif %}"
-          {% if path.rel %}rel="{{ node.rel }}"{% endif %}
-          >
-          {{ node.title }}
-        </a>
-      </li>
-    {% else %}
-      <li>
-        <a href="{{ node.redirect_to }}" class="sidebar-nav-item external" >{{ node.title }}</a>
-      </li>
+    {% unless pageList contains node.title %}
+      {% unless node.redirect_to %}
+        <li>
+          <a
+            {% if forloop.first %}id="_navigation"{% endif %}
+            href="{{ node.url | relative_url }}"
+            class="sidebar-nav-item{% if page.url contains node.url %} active{% endif %}"
+            {% if path.rel %}rel="{{ node.rel }}"{% endif %}
+            >
+            {{ node.title }}
+          </a>
+        </li>
+      {% else %}
+        <li>
+          <a href="{{ node.redirect_to }}" class="sidebar-nav-item external" >{{ node.title }}</a>
+        </li>
+      {% endunless %}
     {% endunless %}
+    {% assign pageList = node.title | append: pageList %}
   {% endfor %}
 </ul>


### PR DESCRIPTION
While rendering the template, maintain a list of pages that have
been printed in the nav menu and don't print pages with the same
title more than once.